### PR TITLE
Update region_backend_service params due to provider changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,9 @@ resource "google_compute_region_backend_service" "accesstier" {
     balancing_mode = "CONNECTION"
   }
   connection_draining_timeout_sec = 0
+  iap {
+    enabled = false
+  }
 }
 
 resource "google_compute_forwarding_rule" "accesstier" {

--- a/main.tf
+++ b/main.tf
@@ -24,8 +24,10 @@ resource "google_compute_region_backend_service" "accesstier" {
   protocol              = "UNSPECIFIED"
   region                = var.region
   backend {
-    group = google_compute_region_instance_group_manager.accesstier_rigm.instance_group
+    group          = google_compute_region_instance_group_manager.accesstier_rigm.instance_group
+    balancing_mode = "CONNECTION"
   }
+  connection_draining_timeout_sec = 0
 }
 
 resource "google_compute_forwarding_rule" "accesstier" {


### PR DESCRIPTION
Defaults changed in google provider 6.X for backend:balancing_mode and connection_draining_timeout_sec parameters. This change makes the old defaults explicit, maintaining current module behaviour between provider versions.